### PR TITLE
Allow users to cancel their badge upgrade

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -101,6 +101,12 @@ def shirt_size(attendee):
         return 'Your shirt size is required'
 
 
+@prereg_validation.Attendee
+def total_cost_over_paid(attendee):
+    if attendee.total_cost < attendee.amount_paid:
+        return 'You have already paid ${}, you cannot reduce your extras below that.'.format(attendee.amount_paid)
+
+
 @validation.Attendee
 @ignore_unassigned_and_placeholders
 def full_name(attendee):

--- a/uber/templates/regform.html
+++ b/uber/templates/regform.html
@@ -50,7 +50,7 @@
         }
     });
 
-    {% if not attendee.is_new %}
+    {% if not attendee.is_new and not attendee.amount_unpaid %}
         // This removes any badge levels lower than the attendee has purchased already
         if (window.BADGE_TYPES) {
             while (_(BADGE_TYPES.options).size() && BADGE_TYPES.options[0].extra < {{ attendee.amount_extra }}) {


### PR DESCRIPTION
Because plugins can now add arbitrary extra costs, we can no longer assume that amount_unpaid == amount_extra, so we can't undo a person's new kick-in level automatically. However, the front-end code assumed that if amount_extra was set, the attendee already paid for it. This stops assuming that while also preventing attendees from dipping below what they've already paid. Fixes https://github.com/Anthrocon-Reg/anthrocon_plugin/issues/54 and fixes https://github.com/magfest/ubersystem/issues/1220.
