### PR TITLE
Allow groups to have checkboxes

### DIFF
--- a/uber/site_sections/groups.py
+++ b/uber/site_sections/groups.py
@@ -32,7 +32,7 @@ class Root:
 
     @log_pageview
     def form(self, session, new_dealer='', first_name='', last_name='', email='', message='', **params):
-        group = session.group(params, bools=['auto_recalc', 'can_add'])
+        group = session.group(params, checkgroups=Group.all_checkgroups, bools=Group.all_bools,)
         if 'name' in params:
             message = check(group)
             if not message:


### PR DESCRIPTION
Anthrocon uses a checkgroup for Groups, but it wasn't saving properly because we weren't using the new all_checkgroups. Fixes https://github.com/Anthrocon-Reg/anthrocon_plugin/issues/53.
