### PR TITLE
Fix sqlalchemy_url for backwards compatibility

### DIFF
--- a/uber/config.py
+++ b/uber/config.py
@@ -301,6 +301,8 @@ class SecretConfig(_Overridable):
 
         if db_connection_string is not None:
             return db_connection_string
+        else:
+            return _config['secret']['sqlalchemy_url']
 
 c = Config()
 _secret = SecretConfig()


### PR DESCRIPTION
MAGFest 2016 uses the sqlalchemy_url from its config file to work, and we still want to support it for now. This shouldn't affect new installs going forward.
