### PR TITLE
Stop using shift_custom_badges wrong

### DIFF
--- a/uber/model_checks.py
+++ b/uber/model_checks.py
@@ -197,7 +197,7 @@ def allowed_to_register(attendee):
 
 @validation.Attendee
 def printed_badge_deadline(attendee):
-    if attendee.is_new and attendee.has_personalized_badge and not c.SHIFT_CUSTOM_BADGES:
+    if attendee.is_new and attendee.has_personalized_badge and c.AFTER_PRINTED_BADGE_DEADLINE:
         return 'Custom badges have already been ordered so you cannot create new {} badges'.format(attendee.badge_type_label)
 
 

--- a/uber/models.py
+++ b/uber/models.py
@@ -545,7 +545,7 @@ class Session(SessionManager):
                 return out_of_range
             elif not badge_num and next > c.BADGE_RANGES[badge_type][1]:
                 return 'There are no more badges available for that type'
-            elif badge_type in c.PREASSIGNED_BADGE_TYPES and not c.SHIFT_CUSTOM_BADGES:
+            elif badge_type in c.PREASSIGNED_BADGE_TYPES and c.AFTER_PRINTED_BADGE_DEADLINE:
                 return 'Custom badges have already been ordered'
 
             if not c.SHIFT_CUSTOM_BADGES:
@@ -671,7 +671,7 @@ class Session(SessionManager):
 
             ribbon_to_use = new_ribbon_type or group.new_ribbon
 
-            if int(new_badge_type) in c.PREASSIGNED_BADGE_TYPES and not c.SHIFT_CUSTOM_BADGES:
+            if int(new_badge_type) in c.PREASSIGNED_BADGE_TYPES and c.AFTER_PRINTED_BADGE_DEADLINE:
                 return 'Custom badges have already been ordered, so you will need to select a different badge type'
             elif diff > 0:
                 for i in range(diff):


### PR DESCRIPTION
For some reason we were using the shift_custom_badges option as a way to turn on and off customization of badges. This was bad because some events want shift_custom_badges to always be off. It now uses the more appropriate printed_badge_deadline option.
