### PR TITLE
Always include Confirm link on admin page

### DIFF
--- a/uber/templates/registration/form.html
+++ b/uber/templates/registration/form.html
@@ -172,9 +172,7 @@
         {% elif c.AT_THE_CON and not attendee.checked_in and not c.NUMBERED_BADGES %}
             <br/> <input type="checkbox" name="check_in" value="yes" {% if check_in %}checked{% endif %} /> Check in this attendee
         {% endif %}
-        {% if attendee.is_transferable %}
-            &nbsp;&nbsp; [<a href="../preregistration/confirm?id={{ attendee.id }}">Confirm/Transfer</a>]
-        {% endif %}
+        &nbsp;&nbsp; [<a href="../preregistration/confirm?id={{ attendee.id }}">Confirm{% if attendee.is_transferable %}/Transfer{% endif %}</a>]
     </div>
 </div>
 


### PR DESCRIPTION
While in AT_THE_CON mode, we were only showing a link to the attendee's "Confirm" page if the attendee was transferable. This link is used frequently by admins, so we now always show it.
