### PR TITLE
Updated path default to point to correct new path

### DIFF
--- a/development-defaults.ini
+++ b/development-defaults.ini
@@ -1,5 +1,5 @@
 
-path = "/uber"
+path = "/rams"
 hostname = "localhost"
 url_root = "https://localhost"
 


### PR DESCRIPTION
the /uber in development-defaults.ini was throwing off the system.  A default-default of /rams works out-of-the-box.